### PR TITLE
WS-14130 - feature/WS-14130-allow-faraday-instrumentation

### DIFF
--- a/lib/paylocity_web_service/connection.rb
+++ b/lib/paylocity_web_service/connection.rb
@@ -95,7 +95,7 @@ module PaylocityWebService
         conn.use Faraday::Request::Authorization, :Bearer, access_token
         conn.request :retry, max: 2
         conn.request :json
-        conn.request :instrumentation
+        conn.request :instrumentation, name: 'request.paylocity'
 
         # conn.use PaylocityWebService::Middleware::Response::RaiseError
         conn.use FaradayMiddleware::ParseJson, :content_type => /\bjson$/

--- a/lib/paylocity_web_service/connection.rb
+++ b/lib/paylocity_web_service/connection.rb
@@ -95,6 +95,7 @@ module PaylocityWebService
         conn.use Faraday::Request::Authorization, :Bearer, access_token
         conn.request :retry, max: 2
         conn.request :json
+        conn.request :instrumentation
 
         # conn.use PaylocityWebService::Middleware::Response::RaiseError
         conn.use FaradayMiddleware::ParseJson, :content_type => /\bjson$/

--- a/lib/paylocity_web_service/version.rb
+++ b/lib/paylocity_web_service/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PaylocityWebService
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Allow Faraday's instrumentation to get events for API calls